### PR TITLE
環境データが500のときのハンドリング

### DIFF
--- a/qoLabFrontEnd/pages/index.vue
+++ b/qoLabFrontEnd/pages/index.vue
@@ -69,16 +69,16 @@ export default {
     let data2
     if (lab.data !== '') {
       const res = await api.get('visialization/envdata').catch(e => {
-        throw e
+        console.debug(e)
+        return e
       })
-      const temperatureIdx = res.data.findIndex(
-        d => d[0].sensorName === 'PressureSensor'
-      )
-      const temphumIdx = res.data.findIndex(
-        d => d[0].sensorName === 'TempHumSensor'
-      )
-      data1 = res.data[temperatureIdx]
-      data2 = res.data[temphumIdx]
+      const temperatureIdx =
+        res.data &&
+        res.data.findIndex(d => d[0].sensorName === 'PressureSensor')
+      const temphumIdx =
+        res.data && res.data.findIndex(d => d[0].sensorName === 'TempHumSensor')
+      data1 = res.data && res.data[temperatureIdx]
+      data2 = res.data && res.data[temphumIdx]
     }
     return {
       labName: lab.data && lab.data.name,


### PR DESCRIPTION
研究室に参加中のときにenvdataが500を返すとレンダリングしてくれないので修正
（さっきのやつは、参加してないときと参加中のハンドリング）
どっかデータがおかしいのかわからんけど500を返す理由特定してバックエンド修正できれば大丈夫な気がする